### PR TITLE
Update niche_vegetation.csv

### DIFF
--- a/niche_vlaanderen/system_tables/niche_vegetation.csv
+++ b/niche_vlaanderen/system_tables/niche_vegetation.csv
@@ -517,89 +517,89 @@ veg_code,veg_type,soil_name,nutrient_level,acidity,mhw_min,mhw_max,mlw_min,mlw_m
 8,Filipendulion,ZV,4,1,46,-35,109,-20,1,2
 8,Filipendulion,ZV,4,2,46,-35,109,-20,1,0
 8,Filipendulion,ZV,4,2,46,-35,109,-20,1,2
-9,Galio - Alliarion,K1,3,1,76,14,157,30,1,2
-9,Galio - Alliarion,K1,3,2,76,14,157,30,1,2
-9,Galio - Alliarion,K1,3,3,76,14,157,30,1,2
-9,Galio - Alliarion,K1,4,1,76,14,157,30,1,2
-9,Galio - Alliarion,K1,4,2,76,14,157,30,1,2
-9,Galio - Alliarion,K1,4,3,76,14,157,30,1,2
-9,Galio - Alliarion,K1,5,1,76,14,157,30,1,2
-9,Galio - Alliarion,K1,5,2,76,14,157,30,1,2
-9,Galio - Alliarion,K1,5,3,76,14,157,30,1,2
-9,Galio - Alliarion,L1,3,1,76,14,157,30,1,2
-9,Galio - Alliarion,L1,3,2,76,14,157,30,1,2
-9,Galio - Alliarion,L1,3,3,76,14,157,30,1,2
-9,Galio - Alliarion,L1,4,1,76,14,157,30,1,2
-9,Galio - Alliarion,L1,4,2,76,14,157,30,1,2
-9,Galio - Alliarion,L1,4,3,76,14,157,30,1,2
-9,Galio - Alliarion,L1,5,1,76,14,157,30,1,2
-9,Galio - Alliarion,L1,5,2,76,14,157,30,1,2
-9,Galio - Alliarion,L1,5,3,76,14,157,30,1,2
-9,Galio - Alliarion,Z1,3,1,124,50,160,50,1,2
-9,Galio - Alliarion,Z1,4,1,124,50,160,50,1,2
-9,Galio - Alliarion,Z1,5,1,124,50,160,50,1,2
-9,Galio - Alliarion,ZV,3,1,124,50,160,50,1,2
-9,Galio - Alliarion,ZV,3,2,124,50,160,50,1,2
-9,Galio - Alliarion,ZV,4,1,124,50,160,50,1,2
-9,Galio - Alliarion,ZV,4,2,124,50,160,50,1,2
-9,Galio - Alliarion,ZV,5,1,124,50,160,50,1,2
-9,Galio - Alliarion,ZV,5,2,124,50,160,50,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,2,36,-3,178,88,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,2,36,-3,178,88,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,2,36,-3,178,88,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,2,36,-3,178,88,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,3,36,-3,178,88,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,3,36,-3,178,88,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,3,36,-3,178,88,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,4,3,36,-3,178,88,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,2,36,-3,178,88,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,2,36,-3,178,88,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,2,36,-3,178,88,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,2,36,-3,178,88,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,3,36,-3,178,88,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,3,36,-3,178,88,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,3,36,-3,178,88,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,K1,5,3,36,-3,178,88,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,2,36,-2,99,31,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,2,36,-2,99,31,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,2,36,-2,99,31,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,2,36,-2,99,31,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,3,36,-2,99,31,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,3,36,-2,99,31,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,3,36,-2,99,31,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,4,3,36,-2,99,31,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,2,36,-2,99,31,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,2,36,-2,99,31,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,2,36,-2,99,31,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,2,36,-2,99,31,3,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,3,36,-2,99,31,1,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,3,36,-2,99,31,1,2
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,3,36,-2,99,31,3,1
-10,RG Phalaris arundinacea-[Convolvulo-Filipend,KV,5,3,36,-2,99,31,3,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,3,1,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,3,1,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,3,2,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,3,2,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,4,1,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,4,1,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,4,2,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,V,4,2,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z1,3,1,13,-44,82,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z1,3,1,13,-44,82,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z1,4,1,13,-44,82,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z1,4,1,13,-44,82,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z2,3,1,13,-44,82,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z2,3,1,13,-44,82,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z2,4,1,13,-44,82,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,Z2,4,1,13,-44,82,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,3,1,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,3,1,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,3,2,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,3,2,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,4,1,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,4,1,11,-44,55,-12,2,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,4,2,11,-44,55,-12,1,2
-11,RG Juncus effusus-[Molinietalia/Lolio-Potent,ZV,4,2,11,-44,55,-12,2,2
+9,Galio-Alliarion,K1,3,1,76,14,157,30,1,2
+9,Galio-Alliarion,K1,3,2,76,14,157,30,1,2
+9,Galio-Alliarion,K1,3,3,76,14,157,30,1,2
+9,Galio-Alliarion,K1,4,1,76,14,157,30,1,2
+9,Galio-Alliarion,K1,4,2,76,14,157,30,1,2
+9,Galio-Alliarion,K1,4,3,76,14,157,30,1,2
+9,Galio-Alliarion,K1,5,1,76,14,157,30,1,2
+9,Galio-Alliarion,K1,5,2,76,14,157,30,1,2
+9,Galio-Alliarion,K1,5,3,76,14,157,30,1,2
+9,Galio-Alliarion,L1,3,1,76,14,157,30,1,2
+9,Galio-Alliarion,L1,3,2,76,14,157,30,1,2
+9,Galio-Alliarion,L1,3,3,76,14,157,30,1,2
+9,Galio-Alliarion,L1,4,1,76,14,157,30,1,2
+9,Galio-Alliarion,L1,4,2,76,14,157,30,1,2
+9,Galio-Alliarion,L1,4,3,76,14,157,30,1,2
+9,Galio-Alliarion,L1,5,1,76,14,157,30,1,2
+9,Galio-Alliarion,L1,5,2,76,14,157,30,1,2
+9,Galio-Alliarion,L1,5,3,76,14,157,30,1,2
+9,Galio-Alliarion,Z1,3,1,124,50,160,50,1,2
+9,Galio-Alliarion,Z1,4,1,124,50,160,50,1,2
+9,Galio-Alliarion,Z1,5,1,124,50,160,50,1,2
+9,Galio-Alliarion,ZV,3,1,124,50,160,50,1,2
+9,Galio-Alliarion,ZV,3,2,124,50,160,50,1,2
+9,Galio-Alliarion,ZV,4,1,124,50,160,50,1,2
+9,Galio-Alliarion,ZV,4,2,124,50,160,50,1,2
+9,Galio-Alliarion,ZV,5,1,124,50,160,50,1,2
+9,Galio-Alliarion,ZV,5,2,124,50,160,50,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,2,36,-3,178,88,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,2,36,-3,178,88,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,2,36,-3,178,88,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,2,36,-3,178,88,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,3,36,-3,178,88,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,3,36,-3,178,88,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,3,36,-3,178,88,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,4,3,36,-3,178,88,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,2,36,-3,178,88,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,2,36,-3,178,88,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,2,36,-3,178,88,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,2,36,-3,178,88,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,3,36,-3,178,88,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,3,36,-3,178,88,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,3,36,-3,178,88,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],K1,5,3,36,-3,178,88,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,2,36,-2,99,31,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,2,36,-2,99,31,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,2,36,-2,99,31,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,2,36,-2,99,31,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,3,36,-2,99,31,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,3,36,-2,99,31,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,3,36,-2,99,31,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,4,3,36,-2,99,31,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,2,36,-2,99,31,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,2,36,-2,99,31,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,2,36,-2,99,31,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,2,36,-2,99,31,3,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,3,36,-2,99,31,1,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,3,36,-2,99,31,1,2
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,3,36,-2,99,31,3,1
+10,RG Phalaris arundinacea-[Convolvulo-Filipendulion],KV,5,3,36,-2,99,31,3,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,3,1,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,3,1,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,3,2,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,3,2,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,4,1,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,4,1,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,4,2,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],V,4,2,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z1,3,1,13,-44,82,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z1,3,1,13,-44,82,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z1,4,1,13,-44,82,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z1,4,1,13,-44,82,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z2,3,1,13,-44,82,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z2,3,1,13,-44,82,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z2,4,1,13,-44,82,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],Z2,4,1,13,-44,82,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,3,1,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,3,1,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,3,2,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,3,2,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,4,1,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,4,1,11,-44,55,-12,2,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,4,2,11,-44,55,-12,1,2
+11,RG Juncus effusus-[Molinietalia/Lolio-Potentillion],ZV,4,2,11,-44,55,-12,2,2
 12,Magnocaricion met Phragmites,K1,2,2,14,-37,55,-3,1,1
 12,Magnocaricion met Phragmites,K1,2,2,14,-37,55,-3,1,2
 12,Magnocaricion met Phragmites,K1,2,3,14,-37,55,-3,1,1
@@ -678,42 +678,42 @@ veg_code,veg_type,soil_name,nutrient_level,acidity,mhw_min,mhw_max,mlw_min,mlw_m
 12,Magnocaricion met Phragmites,V,4,2,9,-37,45,-3,1,2
 12,Magnocaricion met Phragmites,V,4,3,9,-37,45,-3,1,1
 12,Magnocaricion met Phragmites,V,4,3,9,-37,45,-3,1,2
-13,RG Glyceria maxima,K1,2,2,3,-75,75,30,1,0
-13,RG Glyceria maxima,K1,2,2,3,-75,75,30,1,1
-13,RG Glyceria maxima,K1,2,2,3,-75,75,30,1,2
-13,RG Glyceria maxima,K1,2,3,3,-75,75,30,1,0
-13,RG Glyceria maxima,K1,2,3,3,-75,75,30,1,1
-13,RG Glyceria maxima,K1,2,3,3,-75,75,30,1,2
-13,RG Glyceria maxima,K1,3,2,3,-75,75,30,1,0
-13,RG Glyceria maxima,K1,3,2,3,-75,75,30,1,1
-13,RG Glyceria maxima,K1,3,2,3,-75,75,30,1,2
-13,RG Glyceria maxima,K1,3,3,3,-75,75,30,1,0
-13,RG Glyceria maxima,K1,3,3,3,-75,75,30,1,1
-13,RG Glyceria maxima,K1,3,3,3,-75,75,30,1,2
-13,RG Glyceria maxima,K1,4,2,3,-75,75,30,1,0
-13,RG Glyceria maxima,K1,4,2,3,-75,75,30,1,1
-13,RG Glyceria maxima,K1,4,2,3,-75,75,30,1,2
-13,RG Glyceria maxima,K1,4,3,3,-75,75,30,1,0
-13,RG Glyceria maxima,K1,4,3,3,-75,75,30,1,1
-13,RG Glyceria maxima,K1,4,3,3,-75,75,30,1,2
-13,RG Glyceria maxima,L1,2,2,3,-75,75,30,1,0
-13,RG Glyceria maxima,L1,2,2,3,-75,75,30,1,1
-13,RG Glyceria maxima,L1,2,2,3,-75,75,30,1,2
-13,RG Glyceria maxima,L1,2,3,3,-75,75,30,1,0
-13,RG Glyceria maxima,L1,2,3,3,-75,75,30,1,1
-13,RG Glyceria maxima,L1,2,3,3,-75,75,30,1,2
-13,RG Glyceria maxima,L1,3,2,3,-75,75,30,1,0
-13,RG Glyceria maxima,L1,3,2,3,-75,75,30,1,1
-13,RG Glyceria maxima,L1,3,2,3,-75,75,30,1,2
-13,RG Glyceria maxima,L1,3,3,3,-75,75,30,1,0
-13,RG Glyceria maxima,L1,3,3,3,-75,75,30,1,1
-13,RG Glyceria maxima,L1,3,3,3,-75,75,30,1,2
-13,RG Glyceria maxima,L1,4,2,3,-75,75,30,1,0
-13,RG Glyceria maxima,L1,4,2,3,-75,75,30,1,1
-13,RG Glyceria maxima,L1,4,2,3,-75,75,30,1,2
-13,RG Glyceria maxima,L1,4,3,3,-75,75,30,1,0
-13,RG Glyceria maxima,L1,4,3,3,-75,75,30,1,1
-13,RG Glyceria maxima,L1,4,3,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],K1,2,2,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],K1,2,2,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],K1,2,2,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],K1,2,3,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],K1,2,3,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],K1,2,3,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],K1,3,2,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],K1,3,2,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],K1,3,2,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],K1,3,3,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],K1,3,3,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],K1,3,3,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],K1,4,2,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],K1,4,2,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],K1,4,2,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],K1,4,3,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],K1,4,3,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],K1,4,3,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],L1,2,2,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],L1,2,2,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],L1,2,2,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],L1,2,3,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],L1,2,3,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],L1,2,3,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],L1,3,2,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],L1,3,2,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],L1,3,2,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],L1,3,3,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],L1,3,3,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],L1,3,3,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],L1,4,2,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],L1,4,2,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],L1,4,2,3,-75,75,30,1,2
+13,RG Glyceria maxima [Phragmitatea],L1,4,3,3,-75,75,30,1,0
+13,RG Glyceria maxima [Phragmitatea],L1,4,3,3,-75,75,30,1,1
+13,RG Glyceria maxima [Phragmitatea],L1,4,3,3,-75,75,30,1,2
 14,Caricion nigrae,V,1,1,7,-22,57,4,1,0
 14,Caricion nigrae,V,1,1,7,-22,57,4,3,0
 14,Caricion nigrae,V,1,2,7,-22,57,4,1,0
@@ -796,28 +796,28 @@ veg_code,veg_type,soil_name,nutrient_level,acidity,mhw_min,mhw_max,mlw_min,mlw_m
 16,Lolio-Potentillion anserinae,Z2,4,1,6,4,72,66,3,0
 16,Lolio-Potentillion anserinae,Z2,4,1,6,4,72,66,3,1
 16,Lolio-Potentillion anserinae,Z2,4,1,6,4,72,66,3,2
-17,Junco - Molinion,KV,1,2,16,-4,42,13,3,0
-17,Junco - Molinion,KV,1,3,16,-4,42,13,3,0
-17,Junco - Molinion,KV,2,2,16,-4,42,13,3,0
-17,Junco - Molinion,KV,2,3,16,-4,42,13,3,0
-17,Junco - Molinion,LV,1,2,16,2,42,13,3,0
-17,Junco - Molinion,LV,1,3,16,2,42,13,3,0
-17,Junco - Molinion,LV,2,2,16,2,42,13,3,0
-17,Junco - Molinion,LV,2,3,16,2,42,13,3,0
-17,Junco - Molinion,V,1,1,16,-7,42,-1,3,0
-17,Junco - Molinion,V,1,2,16,-7,42,-1,3,0
-17,Junco - Molinion,V,1,3,16,-7,42,-1,3,0
-17,Junco - Molinion,V,2,1,16,-7,42,-1,3,0
-17,Junco - Molinion,V,2,2,16,-7,42,-1,3,0
-17,Junco - Molinion,V,2,3,16,-7,42,-1,3,0
-17,Junco - Molinion,Z1,1,2,18,6,113,86,3,0
-17,Junco - Molinion,Z1,2,2,18,6,113,86,3,0
-17,Junco - Molinion,Z2,1,2,18,6,113,86,3,0
-17,Junco - Molinion,Z2,2,2,18,6,113,86,3,0
-17,Junco - Molinion,ZV,1,1,17,-1,72,7,3,0
-17,Junco - Molinion,ZV,1,2,17,-1,72,7,3,0
-17,Junco - Molinion,ZV,2,1,17,-1,72,7,3,0
-17,Junco - Molinion,ZV,2,2,17,-1,72,7,3,0
+17,Junco-Molinion,KV,1,2,16,-4,42,13,3,0
+17,Junco-Molinion,KV,1,3,16,-4,42,13,3,0
+17,Junco-Molinion,KV,2,2,16,-4,42,13,3,0
+17,Junco-Molinion,KV,2,3,16,-4,42,13,3,0
+17,Junco-Molinion,LV,1,2,16,2,42,13,3,0
+17,Junco-Molinion,LV,1,3,16,2,42,13,3,0
+17,Junco-Molinion,LV,2,2,16,2,42,13,3,0
+17,Junco-Molinion,LV,2,3,16,2,42,13,3,0
+17,Junco-Molinion,V,1,1,16,-7,42,-1,3,0
+17,Junco-Molinion,V,1,2,16,-7,42,-1,3,0
+17,Junco-Molinion,V,1,3,16,-7,42,-1,3,0
+17,Junco-Molinion,V,2,1,16,-7,42,-1,3,0
+17,Junco-Molinion,V,2,2,16,-7,42,-1,3,0
+17,Junco-Molinion,V,2,3,16,-7,42,-1,3,0
+17,Junco-Molinion,Z1,1,2,18,6,113,86,3,0
+17,Junco-Molinion,Z1,2,2,18,6,113,86,3,0
+17,Junco-Molinion,Z2,1,2,18,6,113,86,3,0
+17,Junco-Molinion,Z2,2,2,18,6,113,86,3,0
+17,Junco-Molinion,ZV,1,1,17,-1,72,7,3,0
+17,Junco-Molinion,ZV,1,2,17,-1,72,7,3,0
+17,Junco-Molinion,ZV,2,1,17,-1,72,7,3,0
+17,Junco-Molinion,ZV,2,2,17,-1,72,7,3,0
 18,Calthion palustris,K1,2,1,25,-16,68,18,2,0
 18,Calthion palustris,K1,2,1,25,-16,68,18,2,2
 18,Calthion palustris,K1,2,1,25,-16,68,18,3,0
@@ -1180,12 +1180,12 @@ veg_code,veg_type,soil_name,nutrient_level,acidity,mhw_min,mhw_max,mlw_min,mlw_m
 23,Venige heide,Z2,1,1,20,1,74,29,1,0
 23,Venige heide,ZV,1,1,20,-6,74,13,1,0
 23,Venige heide,ZV,1,2,20,-6,74,13,1,0
-24,Oxycocco - Ericion,V,1,1,13,-17,43,-8,0,0
-24,Oxycocco - Ericion,V,1,2,13,-17,43,-8,0,0
-24,Oxycocco - Ericion,Z1,1,1,16,-11,23,7,0,0
-24,Oxycocco - Ericion,Z2,1,1,16,-11,23,11,0,0
-24,Oxycocco - Ericion,ZV,1,1,13,-17,3,-8,0,0
-24,Oxycocco - Ericion,ZV,1,2,13,-17,3,-8,0,0
+24,Oxycocco-Ericion,V,1,1,13,-17,43,-8,0,0
+24,Oxycocco-Ericion,V,1,2,13,-17,43,-8,0,0
+24,Oxycocco-Ericion,Z1,1,1,16,-11,23,7,0,0
+24,Oxycocco-Ericion,Z2,1,1,16,-11,23,11,0,0
+24,Oxycocco-Ericion,ZV,1,1,13,-17,3,-8,0,0
+24,Oxycocco-Ericion,ZV,1,2,13,-17,3,-8,0,0
 25,Rynchosporion albae,Z1,1,1,-2,-44,66,-12,0,0
 25,Rynchosporion albae,Z1,1,1,-2,-44,66,-12,0,2
 25,Rynchosporion albae,Z1,1,1,-2,-44,66,-12,1,0
@@ -1204,4 +1204,4 @@ veg_code,veg_type,soil_name,nutrient_level,acidity,mhw_min,mhw_max,mlw_min,mlw_m
 27,RG Myrica gale [Ericion tetralicis],Z2,1,1,76,-2,126,33,1,0
 27,RG Myrica gale [Ericion tetralicis],ZV,1,1,22,-3,126,9,1,0
 27,RG Myrica gale [Ericion tetralicis],ZV,1,2,22,-3,126,9,1,0
-28,Calluno - Genistion pilosae,Z1,1,1,172,51,196,114,1,0
+28,Calluno-Genistion pilosae,Z1,1,1,172,51,196,114,1,0


### PR DESCRIPTION
Update in reaction to issue Names for vegetation types are incomplete #79
Changes:
veg 10 = RG Phalaris arundinacea-[Convolvulo-Filipendulion]
veg 11 = RG Juncus effusus-[Molinietalia/Lolio-Potentillion]
veg 13 = RG Glyceria maxima [Phragmitatea]
Also removed the spaces around the hyphen in veg 9 Galio-Alliarion, veg 17 Junco-Molinion, veg 24 Oxycocco-Ericion, veg 28 Calluno-Genistion pilosae