### PR TITLE
Running Niche - correct activate niche_vlaanderen

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -95,7 +95,7 @@ and activate the environment:
 
 .. code-block:: default
 
-    (C:\Users\johan\Miniconda3) C:\Users\johan> activate niche_vlaanderen
+    (C:\Users\johan\Miniconda3) C:\Users\johan> activate niche
 
 Optionally - Jupyter Notebook
 =============================


### PR DESCRIPTION
In the installation section, Running Niche subsection:
activate niche_vlaanderen should probably be activate niche