### PR TITLE
Change structure of the documentation MODEL part

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,14 +6,18 @@
 .. include:: ../README.rst
 
 This documentation is split in two parts:
- * The first part :doc:`model` (in Dutch) describes the background of the NICHE model.
+ * The first part (in Dutch) describes the background of the NICHE model, gives information about the input layers and the calibration of the model.
  * The second part describes the ``niche_vlaanderen`` package.
 
 .. toctree::
   :caption: Model
   :maxdepth: 2
 
+  notendop
   model
+  invoer
+  kalibratie
+  overstroming
 
 .. toctree::
   :caption: Package

--- a/docs/kalibratie.rst
+++ b/docs/kalibratie.rst
@@ -1,0 +1,5 @@
+###########
+Kalibratie 
+###########
+
+(nog even geduld, dit hoofdstuk wordt binnenkort aangevuld)

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -14,9 +14,7 @@ De berekening gebeurt in drie stappen:
 .. toctree::
   :caption: Overzicht
 
-  invoer
   trofie
   zuur
   vegetatie
   codetables
-  overstroming

--- a/docs/notendop.rst
+++ b/docs/notendop.rst
@@ -1,0 +1,8 @@
+##############
+In a notendop
+##############
+
+(nog even geduld, dit hoofdstuk wordt binnenkort aangevuld)
+
+
+


### PR DESCRIPTION
Create this new expanded structure:
MODEL
- in a notendop
- beschrijving model
- invoer rasters
- kalibratie model
- overstromingsmodule
(to replace the old structure:
MODEL
- beschrijving model)
