### PR TITLE
Fix appveyor

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 pytest
 pytest-cov
-pip
 wheel
 matplotlib


### PR DESCRIPTION
By not requiring pip in dev requirements. You would not be able to use
the file anyway if you don't have pip.