### PR TITLE
Fix affine warning (closes: #266)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
   - export PROJ_LIB=/usr/share/proj
 
 install:
-  - pip install rasterio==$RASTERIO_VERSION
   - pip install -r dev-requirements.txt
   - pip install coveralls
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,16 @@ cache:
   directories:
     - ~/.cache/pip
 
-matrix:
-  exclude:
-      - python: "3.7"
-        env: "RASTERIO_VERSION=0.36.0"
 env:
-  matrix:
-    - RASTERIO_VERSION=0.36.0
-    - RASTERIO_VERSION=1.0.22
   global:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
-# - "nightly"
+  - "3.8"
 
 script: 
   - pytest --cov niche_vlaanderen --cov-report term-missing --verbose --tb=long
@@ -52,16 +44,14 @@ after_success:
 
 before_deploy:
   - pip install -r doc-requirements.txt
-  - "if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then sphinx-build docs -a doc/_build/html;fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then sphinx-build docs -a doc/_build/html;fi"
 
 deploy:
     - user: stvhoey
       distributions: sdist bdist_wheel
       provider: pypi
-      on: 
-         condition: "$RASTERIO_VERSION=0.36.0"
       true:
-        python: 3.5
+        python: 3.7
         repo: inbo/niche_vlaanderen
         tags: true
       password:
@@ -84,5 +74,4 @@ deploy:
       local_dir: doc/_build/html
       on:
         branch: master
-        python: 3.5
-        condition: "$RASTERIO_VERSION=0.36.0"
+        python: 3.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest
+pytest>=4.6 # bumped for compatibility with latest pytest-cov
 pytest-cov
 wheel
 matplotlib

--- a/niche_vlaanderen/niche.py
+++ b/niche_vlaanderen/niche.py
@@ -356,7 +356,7 @@ class Niche(object):
             # find out which cells have invalid values
             bad_points = np.where(higher)
             # convert these cells into the projection system
-            bad_points = bad_points * self._context.transform
+            bad_points = self._context.transform * bad_points
 
             print("Warning: Not all {} values are lower than {}".format(a, b))
             print("coordinates with invalid values are:")

--- a/niche_vlaanderen/niche.py
+++ b/niche_vlaanderen/niche.py
@@ -172,7 +172,6 @@ class Niche(object):
             else:
                 s = '# Newer niche_vlaanderen  %s available' % last
         except:
-            raise
             s = "# Error determinining last upstream version"
         return s
 


### PR DESCRIPTION
This pr fixes an affine deprecation warning and fixes the travis build (also new dependencies).

Travis will no longer run using rasterio 0.36. Support is deprecated as of niche >1.1