### PR TITLE
Limit namespace to base classes/functions

### DIFF
--- a/niche_vlaanderen/__init__.py
+++ b/niche_vlaanderen/__init__.py
@@ -1,6 +1,8 @@
-from .acidity import Acidity # noqa
 from .niche import Niche, NicheDelta, conductivity2minerality # noqa
+from .acidity import Acidity # noqa
 from .nutrient_level import NutrientLevel # noqa
 from .vegetation import Vegetation # noqa
 from .version import __version__ # noqa
 from .flooding import Flooding # noqa
+
+__all__ = ['Acidity', 'Niche', 'NicheDelta', 'conductivity2minerality', 'NutrientLevel', 'Vegetation', 'Flooding']


### PR DESCRIPTION
Closes #55

Note that ipython usually does not respect these options, so end-users
will probably not notice much of a difference.

ipython/ipykernel#129