### PR TITLE
installation.rst: install jupyter with pip instead of conda

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -40,7 +40,8 @@ will not work) and `jupyter` notebook, which allows interactive usage from a web
 
 .. code-block:: shell
 
-    conda install matplotlib jupyter
+    conda install matplotlib
+    pip install jupyter
 
 You can verify the installation was successful by running the cli interface.
 Note you must activate niche once more, because some changes were made during


### PR DESCRIPTION
Apparently  `conda install jupyter` hasn't been working as expected the last few weeks.

We might update the instructions to help unexperienced users and suggest they use pip instead (of if you know  a cleaner way or a way to get `conda install jupyter` to work: suggestions welcome).

Another option: let `conda install jupyter` in the standard instructions, but add the pip solution in the FAQ