### PR TITLE
Advanced_usage.ipynb: correction doc for abiotic

### DIFF
--- a/docs/advanced_usage.ipynb
+++ b/docs/advanced_usage.ipynb
@@ -513,7 +513,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we will create a new niche model using the same options as our previous full models, but we will add the previously calculated acidity as input: in this case, this acidity grid will be used (and not calculated from the other grids). Note that we use the `read_config_file` method (and not  `run_config_file`) because we still want to edit the configuration before running."
+    "Next we will create a new niche model using the same options as our previous full models, but we will add the previously calculated nutrient level as input: in this case, this nutrient level grid will be used (and not calculated from the other grids). Note that we use the `read_config_file` method (and not  `run_config_file`) because we still want to edit the configuration before running."
    ]
   },
   {
@@ -548,8 +548,11 @@
    ],
    "source": [
     "adjusted = nv.Niche()\n",
+    "# set the input layers as usual:\n",
     "adjusted.read_config_file(\"full.yml\")\n",
+    "# now select a custom layer for the nutrient level:\n",
     "adjusted.set_input(\"nutrient_level\", \"output_abiotic/adjusted_nutrient.tif\")\n",
+    "# since we do not define a custom acidity layer to use, acidity will be calculated as usual\n",
     "adjusted.name = \"adjusted_nutrient_level\"\n",
     "adjusted.run()\n",
     "\n",


### PR DESCRIPTION
in the example we use a custom nutrient level while the text was mentioning a custom acidity layer => corrected