### PR TITLE
Documentation: add separate "running niche" item

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,9 @@ Deze documentatie bestaat uit **twee delen**:
   :maxdepth: 2
 
   installation
-  codetables
+  running
   tutorials
+  codetables
   cli
   lowlevel
   faq

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -110,30 +110,3 @@ will not work) and `jupyter` notebook, which allows interactive usage from a web
 
     conda install matplotlib jupyter
 
-Running niche
-=============
-
-Whenever you want to use niche_vlaanderen (either from the command line or Python) you need
-to start from the `Anaconda prompt` (in the start menu)
-and activate the environment:
-
-.. code-block:: shell
-
-    (C:\Users\myusername\Miniconda3) C:\Users\myusername> conda activate niche
-
-Optionally - Jupyter Notebook
-=============================
-
-If you want to run niche_vlaanderen interactively, we recommend using a [jupyter notebook](http://jupyter.org/).
-To run this, from the `Anaconda prompt` do:
-
-.. code-block:: default
-
-    (C:\Users\myusername\Miniconda3) C:\Users\myusername> conda activate niche
-    (niche) C:\Users\myusername> jupyter notebook
-
-This should open a webbrowser pointing towards http://localhost:8888 . If your browser does not open, try looking for the correct URL at the `Anaconda prompt`.
-
-The :doc:`tutorials` will use these jupyter notebooks, and are the best place to continue from here.
-
-

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -1,0 +1,28 @@
+##############
+Running niche
+##############
+
+Whenever you want to use niche_vlaanderen (either from the command line or Python) you need
+to start from the `Anaconda/Miniconda prompt` (in the start menu)
+and activate the environment (in this example, an environment you called `niche` during the installation):
+
+.. code-block:: shell
+
+    (C:\Users\myusername\Miniconda3) C:\Users\myusername> conda activate niche
+
+Optionally - Jupyter Notebook
+=============================
+
+If you want to run niche_vlaanderen interactively, we recommend using a [jupyter notebook](http://jupyter.org/).
+To run this, from the `Anaconda/Miniconda prompt` do:
+
+.. code-block:: default
+
+    (C:\Users\myusername\Miniconda3) C:\Users\myusername> conda activate niche
+    (niche) C:\Users\myusername> jupyter notebook
+
+This should open a webbrowser pointing towards http://localhost:8888 . If your browser does not open, try looking for the correct URL at the `Anaconda prompt`.
+
+The :doc:`tutorials` will use these jupyter notebooks, and are the best place to continue from here.
+
+


### PR DESCRIPTION
- added a separate running.rst with instructions to run niche
- removed the running instructions from installation.rst
- added 'running' to the menu structure and put 'tutorials' before 'code tables' ('tutorials' is often used by new users, 'code tables' is more technical)

Requested by unfrequent users who could not find the instructions to run NICHE after the initial installation (was a bit hidden in installation.rst)