### PR TITLE
Don't add pygeos as a separate dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - geopandas
   - numpy
   - pandas
-  - pygeos
   - pyyaml
   - rasterio
   - rasterstats>=0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ rasterio
 pyyaml
 rasterstats>=0.17
 geopandas
-pygeos
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ requirements = [
         'pyyaml',
         'rasterstats>=0.17',
         'tqdm',
-        'pygeos',
         'geopandas'
         ]
 


### PR DESCRIPTION
Pygeos is no longer maintained. No direct import in niche and geopandas no longer requires it.

Should fix unit tests.