### PR TITLE
handle unsuitable soil types 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: build package
         run: |
+          sudo apt-get update
           sudo apt-get -y install libgdal-dev gdal-bin pandoc
           python -m pip install --upgrade pip
           pip install coveralls wheel

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,5 @@ result_images/*
 
 # package specific content
 tests/result_images/*
-*/log.txt
+**/log.txt
 *_output*
-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -116,4 +116,6 @@ result_images/*
 
 # package specific content
 tests/result_images/*
-/tests/log.txt
+*/log.txt
+*_output*
+log.txt

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,5 +9,6 @@ Contributors
 * Stijn Van Hoey
 * Cécile Herr
 * Dries Adriaens
+* Baris Oztas <baris@bariso.dev>
 
 Why not join?

--- a/niche_vlaanderen/nutrient_level.py
+++ b/niche_vlaanderen/nutrient_level.py
@@ -120,6 +120,7 @@ class NutrientLevel(object):
             table_sel = table_sel.reset_index(drop=True)
             soil_sel = soil_code_array == code
             ix = np.digitize(msw_array[soil_sel], table_sel.msw_max, right=False)
+            ix = np.clip(ix, 0, len(table_sel) - 1)
             result[soil_sel] = table_sel["nitrogen_mineralisation"].reindex(ix).values
 
         # The intermediate mineralisation array is a float32 array with np.nan as nodata

--- a/niche_vlaanderen/vegetation.py
+++ b/niche_vlaanderen/vegetation.py
@@ -39,7 +39,7 @@ class VegSuitable(IntEnum):
                 if i & j == j:
                     legend_items += [VegSuitable(i & j).name.lower()]
             legend[i] = "+".join(legend_items) + " suitable"
-        legend[0] = "soil unsuitable"
+        legend[0] = "soil unsuitable or unknown"
 
         # only select possible combinations for legend
         sel = VegSuitable.possible()

--- a/tests/test_niche.py
+++ b/tests/test_niche.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from collections import Counter
-import distutils.spawn
 import os
 import shutil
 import subprocess

--- a/tests/test_nutrient_level.py
+++ b/tests/test_nutrient_level.py
@@ -19,12 +19,12 @@ class TestNutrientLevel:
     def test_nitrogen_mineralisation_nodata(self):
         """Correct nitrogen mineralisation calculated from fixed-value
         grids with non-empty mask"""
-        soil_code = np.array([14, 14, 255, 10], dtype="uint8")
-        msw =np.array([-33, -33, np.nan, -33], dtype="float32")
+        soil_code = np.array([14, 14, 255], dtype="uint8")
+        msw =np.array([-33, -33, np.nan], dtype="float32")
 
         nl = niche_vlaanderen.NutrientLevel()
         result = nl._calculate_mineralisation(soil_code, msw)
-        np.testing.assert_equal(np.array([75, 75, np.nan, 0]), result)
+        np.testing.assert_equal(np.array([75, 75, np.nan]), result)
         assert result.dtype == np.float32
 
     def test_nitrogen_mineralisation_not_suitable(self):

--- a/tests/test_nutrient_level.py
+++ b/tests/test_nutrient_level.py
@@ -19,12 +19,23 @@ class TestNutrientLevel:
     def test_nitrogen_mineralisation_nodata(self):
         """Correct nitrogen mineralisation calculated from fixed-value
         grids with non-empty mask"""
-        soil_code = np.array([14, 14, 255], dtype="uint8")
-        msw =np.array([-33, -33, np.nan], dtype="float32")
+        soil_code = np.array([14, 14, 255, 10], dtype="uint8")
+        msw =np.array([-33, -33, np.nan, -33], dtype="float32")
 
         nl = niche_vlaanderen.NutrientLevel()
         result = nl._calculate_mineralisation(soil_code, msw)
-        np.testing.assert_equal(np.array([75, 75, np.nan]), result)
+        np.testing.assert_equal(np.array([75, 75, np.nan, 0]), result)
+        assert result.dtype == np.float32
+
+    def test_nitrogen_mineralisation_not_suitable(self):
+        """Correct nitrogen mineralisation calculated from fixed-value
+        grids with non-empty mask"""
+        soil_code = np.array([10], dtype="uint8")
+        msw =np.array([-33], dtype="float32")
+
+        nl = niche_vlaanderen.NutrientLevel()
+        result = nl._calculate_mineralisation(soil_code, msw)
+        np.testing.assert_equal(np.array([0]), result)
         assert result.dtype == np.float32
 
     def test_borders(self):


### PR DESCRIPTION
Closes #395.

Since nitrogen_mineralisation.csv only has 1 row for soil_name NG (soil_code 10), with msw_max=-5000, the following steps returns array with values 1.

```
np.digitize(msw_array[soil_sel], table_sel.msw_max, right=False)
array([1, 1, 1, ..., 1, 1, 1], shape=(110880,))
```

After that, `reindex([1, 1, 1, ..., 1, 1, 1],)` step returns NaN instead of 0. Then, NaNs propagate from here. So this fix handles by making sure 1 row table case is handled.